### PR TITLE
Hide overflow of long object names to maintain layout.

### DIFF
--- a/public/stylesheets/dbv.css
+++ b/public/stylesheets/dbv.css
@@ -58,6 +58,12 @@ h3 {
 h4 {
     font-size: 12px;
 }
+td.object-label label {
+    width: 207px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .nomargin {
     margin-bottom: 0 !important
 }

--- a/templates/schema.php
+++ b/templates/schema.php
@@ -25,7 +25,7 @@
                         <td class="center">
                             <input type="checkbox" name="schema[]" value="<?php echo $name; ?>" id="object-<?php echo $name; ?>" style="margin-top: 0;" />
                         </td>
-                        <td>
+                        <td class="object-label">
                             <label for="object-<?php echo $name; ?>">
                                 <?php echo $name; ?>
                             </label>


### PR DESCRIPTION
This preserves the page layout keeping elements shown while not letting extra long schema names push the table out under the revisions element.