### PR TITLE
fix http authorization

### DIFF
--- a/DBV.php
+++ b/DBV.php
@@ -49,7 +49,7 @@ class DBV
                 $headers = apache_request_headers();
                 $authorization = array_key_exists('HTTP_AUTHORIZATION', $headers)
                     ? $headers['HTTP_AUTHORIZATION']
-                    : '';
+                    : (array_key_exists('Authorization', $headers)?$headers['Authorization']:'');
             }
         }
 


### PR DESCRIPTION
On WampServer 2.5, Apache 2.4.9 and PHP 5.5.12